### PR TITLE
Disabling comma-dangle

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,11 @@ module.exports = {
         'avoidEscape': true,
         'allowTemplateLiterals': true
       }
-    ]
+    ],
 
+    // http://eslint.org/docs/rules/comma-dangle
+    'comma-dangle': [
+      2, 'never'
+    ]
   }
 }


### PR DESCRIPTION
http://eslint.org/docs/rules/comma-dangle

since IE6 i never put trailing comas in arrays and objects. most of style guides disable them too.

although there is an opposite preference as well. apparently they like them at airbnb for some reason
