### PR TITLE
Disabling the no-console rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,11 @@ module.exports = {
         'avoidEscape': true,
         'allowTemplateLiterals': true
       }
-    ]
+    ],
 
+    // http://eslint.org/docs/rules/quotes
+    "no-console": [
+      0
+    ]
   }
 }


### PR DESCRIPTION
we're a bit `console.log` heavy i think, so disabling the rule makes sense
