### PR TITLE
Disabling one-var

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,14 @@ module.exports = {
     // http://eslint.org/docs/rules/comma-dangle
     'comma-dangle': [
       2, 'never'
+    ],
+
+    // http://eslint.org/docs/rules/one-var
+    'one-var': [
+      0
+    ],
+    'one-var-declaration-per-line': [
+      0
     ]
   }
 };


### PR DESCRIPTION
basically allows this:

``` js
let one=1, two=2, three=3;
```

instead of forcing this

``` js
let one=1;
let two=2;
let three=3;
```

if find it is useful to just put things in one line when the definitions are mundane 
