### PR TITLE
Disabling strict mode warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,11 @@ module.exports = {
     // http://eslint.org/docs/rules/no-shadow
     "no-shadow": [
       0
+    ],
+
+    // http://eslint.org/docs/rules/strict
+    'strict': [
+      0
     ]
   }
 };


### PR DESCRIPTION
the default airbnb config is built for more of a babel style environment, and complains when one puts a global `'use strict';` at the top of a file. unfortunately, we're living in the pastness of the node 4 world, where block scope variables do weird shit without a `use strict` warning.

until we're well in the rainbowy world of node 6, where use strict is the thing of the past, we should disable this
