### PR TITLE
No space before function parenthesis

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 module.exports = {
   extends: 'eslint-config-airbnb',
   env: {
-    es6:   true,
-    node:  true,
+    es6: true,
+    node: true,
     mocha: true
   },
   rules: {
@@ -28,6 +28,11 @@ module.exports = {
     // http://eslint.org/docs/rules/comma-dangle
     'comma-dangle': [
       2, 'never'
+    ]
+
+    // http://eslint.org/docs/rules/space-before-function-paren
+    'space-before-function-paren': [
+      2, { 'anonymous': 'never', 'named': 'never' }
     ]
   }
 };


### PR DESCRIPTION
I prefer no spaces (`function()` not `function ()`) but I think we can ignore this and leave it up to each developer?
