### PR TITLE
Warn when not using arrow functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,9 @@ module.exports = {
     // http://eslint.org/docs/rules/comma-dangle
     'comma-dangle': [
       2, 'never'
-    ]
+    ],
+
+    // http://eslint.org/docs/rules/prefer-arrow-callback
+    'prefer-arrow-callback': 1
   }
 };


### PR DESCRIPTION
We should encourage using arrow functions - because they're great! - but there are times when they're not necessary, so let's not make it required.
