### PR TITLE
Warn on global requires

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,9 @@ module.exports = {
     // http://eslint.org/docs/rules/comma-dangle
     'comma-dangle': [
       2, 'never'
-    ]
+    ],
+
+    // http://eslint.org/docs/rules/global-require
+    'global-require': 0
   }
 };


### PR DESCRIPTION
Often you need to use `require` in part of `if` statements or what not - sometimes for dev related stuff - so I think a warning will suffice just to remind you if you're using it incorrectly.
