### PR TITLE
Disabling the no-param-reassignment rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,11 @@ module.exports = {
       0
     ],
 
+    // http://eslint.org/docs/rules/no-param-reassign
+    "no-param-reassign": [
+      2, { "props": false }
+    ],
+
     // http://eslint.org/docs/rules/strict
     'strict': [
       0


### PR DESCRIPTION
So, this is a bit of a tricky one. By default they prohibit modifications of objects that come as parameters. for example:

``` js
const obj = { ... };

function smth(thing) {
   thing.something = 'something'; // <- explodes
}

smth(obj);
```

this kind of makes sense as it tries to help you to write functions with less side effects. but i think it is rather impractical and blocks a whole layer of valid solutions like factories, strategies and such. even less abstract cases like for example patching a `req` in express middleware.

``` js
app.get('/posts', authenticate, function * (req, res) {
   const posts = yield req.currentUser.posts();
   res.send(posts);
});
function * authenticate(req, res, next) {
  const token = req.get('Authorization');
  const user = yield User.findByToken(token);
  req.currentUser = user;
  next();
}
```

which is a pretty standard practice.

just to be clear, i'm not disabling the _whole_ rule, only the part that is responsible for changing object properties
