### PR TITLE
Warn on preferring stateless components

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,11 +49,16 @@ module.exports = {
       0
     ],
 
-    'mocha/no-exclusive-tests': 'error'
+    'mocha/no-exclusive-tests': [
       2, 'never'
     ]
 
     // http://eslint.org/docs/rules/func-names
     'func-names': 0
+
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md
+    'react/prefer-stateless-function': [
+      1
+    ]
   }
 };


### PR DESCRIPTION
There is a bottleneck here when using ES7 decorators.

You can only use '@' syntax decorators on class definitions.  So using a basic class (with just `render`) the linter will throw an error, and ask you to instead use stateless component syntax.

For example:

``` js
@connect(
  state => ({ raphael: state.turtles.raphael })
)
export class TMNT extends React.Component {
  render() {
    return <div>{this.props.raphael}</div>;
  }
}
```

The above will throw an error with `prefer-stateless-function`.

To use decorators on stateless components, we can write it using function style:

``` js
export const TMNT = ({ raphael }) =>
  <div>{this.props.raphael}</div>;

export connect(state => ({ raphael: state.turtles.raphael })(TMNT);
```

I **prefer using stateless where possible**, but when expanding this container with more methods (which it most likely will be expanded if you've deemed it necessary to subscribe to state) I now need to change the format to the first example.

**Stateless components are great** and we **_should_ be using** them where possible but currently this rules prevents using the proposed decorator syntax (eg. `@decorator`) on components without having to switch from stateless <-> class.  It just doesn't seem to play nice, yet.  Sometimes you start building the component and you don't have all the other lifecycle methods filled in just yet, which can be frustrating and time consuming as you're having to redo the structure of the component just to make the linter happy.

So I vote, for now, we use a warning, which should still ensure that we think about using stateless - which is great not just for syntax conciseness, but also for performance (no internal state and extraneous lifecycle methods added) - but it won't hamper productivity as I've outlined above.

[Also referenced here](https://github.com/yannickcr/eslint-plugin-react/issues/501).

Thoughts?
